### PR TITLE
[ISSUE-03] 크롬 브라우저의 백그라운드 탭의 FPS변화

### DIFF
--- a/issue-03/background-fps.html
+++ b/issue-03/background-fps.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>rAF & VisibilityState 실험</title>
+        <link href="./sytles.css" rel="stylesheet" />
+    </head>
+    <body>
+        <h1>requestAnimationFrame Throttling 실험</h1>
+        <div id="info">
+            <p>
+                <strong>Visibility:</strong>
+                <span id="visibility">visible</span>
+            </p>
+            <p><strong>FPS:</strong> <span id="fps">0</span></p>
+        </div>
+        <div id="box"></div>
+        <div id="log"></div>
+
+        <script>
+            const box = document.getElementById("box");
+            const fpsEl = document.getElementById("fps");
+            const visEl = document.getElementById("visibility");
+            const logEl = document.getElementById("log");
+
+            let x = 0;
+            let lastFrameTime = performance.now();
+            let frameCount = 0;
+            let fps = 0;
+            let lastLoggedFPS = 0;
+            let fallbackTimer = null;
+
+            function log(msg) {
+                const timestamp = new Date().toLocaleTimeString();
+                logEl.textContent += `[${timestamp}] ${msg}\n`;
+                logEl.scrollTop = logEl.scrollHeight;
+            }
+
+            document.addEventListener("visibilitychange", () => {
+                visEl.textContent = document.visibilityState;
+                log(`탭 상태 변경: ${document.visibilityState}`);
+
+                if (document.visibilityState === "hidden") {
+                    frameCount = 0;
+                    lastFrameTime = performance.now();
+                    fallbackTimer = setInterval(() => {
+                        const now = performance.now();
+                        const elapsed = now - lastFrameTime;
+                        const currentFPS = Math.round(
+                            (frameCount * 1000) / elapsed
+                        );
+                        fpsEl.textContent = currentFPS;
+                        log(`FPS (백그라운드): ${currentFPS}`);
+                        frameCount = 0;
+                        lastFrameTime = now;
+                    }, 1000);
+                } else {
+                    clearInterval(fallbackTimer);
+                    fallbackTimer = null;
+                }
+            });
+
+            function updateFPS(now) {
+                frameCount++;
+                if (now - lastFrameTime >= 1000) {
+                    fps = frameCount;
+                    fpsEl.textContent = fps;
+                    if (fps !== lastLoggedFPS) {
+                        log(`FPS: ${fps}`);
+                        lastLoggedFPS = fps;
+                    }
+                    frameCount = 0;
+                    lastFrameTime = now;
+                }
+            }
+
+            function animate(now) {
+                if (document.visibilityState === "visible") {
+                    updateFPS(now);
+                } else {
+                    frameCount++;
+                }
+                x = (x + 1) % window.innerWidth;
+                box.style.transform = `translateX(${x}px)`;
+                requestAnimationFrame(animate);
+            }
+
+            requestAnimationFrame(animate);
+        </script>
+    </body>
+</html>

--- a/issue-03/sytles.css
+++ b/issue-03/sytles.css
@@ -1,0 +1,25 @@
+body {
+    font-family: sans-serif;
+    padding: 20px;
+}
+#box {
+    width: 50px;
+    height: 50px;
+    background-color: tomato;
+    position: absolute;
+    top: 100px;
+    left: 0;
+    border-radius: 10px;
+}
+#info {
+    margin-bottom: 20px;
+}
+#log {
+    margin-top: 20px;
+    white-space: pre-line;
+    background: #f0f0f0;
+    padding: 10px;
+    border: 1px solid #ccc;
+    max-height: 200px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
1. 브라우저의 탭 변경 시 어떤 일이 일어날까?
브라우저의 탭 변경 시 `document.visibility`값이 자동으로 `hidden`으로 설정 됩니다. 이는 해당 탭이 백그라운드로 전환되었음을 의미합니다.

2. `document.visibility`값이 `hidden`일때 어떤 일이 발생하는가?
[scheduler_state_machine.cc](https://github.com/chromium/chromium/blob/9165920df430203d7cb3e9647f5481c479fbc266/cc/scheduler/scheduler_state_machine.cc#L489) 파일을 보면, 크롬은 탭이 비활성화되면 `BeginFrame`의 **구독을 해제**합니다.
이로 인해 해당 탭은 더 이상 **프레임을 생성하지 않게 되며, 애니메이션도 멈추게 됩니다.**

3. 그럼 백그라운드에서는 아무 작업도 안되는건가요?
대부분의 경우는 맞습니다. 하지만 [Chrome 공식 블로그](https://developer.chrome.com/blog/background_tabs?hl=ko)에서 언급되었듯, **오디오나 동영상이 재생 중인 탭은 예외적으로 계속 포그라운드처럼 동작**합니다.
예를 들어 음악을 재생중인 탭은 `requestAnimationFrame`도 계속 호출될 수 있습니다. 이런 탭들은 **스로틀링되지 않고 CPU자원을 계속 소모**하게 됩니다.

참고: `setInterval`이나 `setTimeout` 는요?
탭이 백그라운드 상태가 되면 `setInterval`이나 `setTimeout`은 ``1초에 1회 이하로 강제 제한**이 됩니다. 위 예시와 비슷하게 불필요한 자원 사용을 줄이기 위함입니다.

@BangDori 크롬은 메모리가 부족해지면 자동으로 탭의 자원을 회수하고 나중에 다시 focus를 잡게되면 새로고침 하는 식으로 자원을 관리하는것으로 알고있습니다. 이때 블로그나, PR같이 긴 글을 작성중이었다면 해당 데이터가 모두 날아가게 됩니다. 이런 문제점을 위의 `document.visibility`값의 변화를 감지하고 자동으로 로컬스토리지로 이동시켜주고 focus가 돌아오면 로컬스토리지에서 데이터를 받아오며 UX향상을 노려볼 수 있을 것 같은데 다른 의견이 있을까요?