### PR TITLE
[ISSUE-02] 자바스크립트의 Call by Value와 참조 타입 전달 방식 분석

### DIFF
--- a/issue-03/primitive-type-experiment.js
+++ b/issue-03/primitive-type-experiment.js
@@ -1,0 +1,54 @@
+/**
+ * 기본형(Primitive type) 변수의 함수 전달 시 복사 동작 실험
+ *
+ * JavaScript Primitive Type:
+ * - Null
+ * - Undefined
+ * - Boolean
+ * - Number
+ * - BigInt
+ * - String
+ * - Symbol
+ *
+ * 링크: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Data_structures#primitive_values
+ */
+
+// 1. Number 타입 실험
+function modifyNumber(num) {
+  console.log("함수 내부 - 전달받은 num:", num);
+  num = 100; // 새로운 값 할당
+  console.log("함수 내부 - 변경된 num:", num);
+}
+
+let originalNum = 10;
+console.log("함수 호출 전 originalNum:", originalNum);
+modifyNumber(originalNum);
+console.log("함수 호출 후 originalNum:", originalNum);
+
+console.log("\n-------------------\n");
+
+// 2. String 타입 실험
+function modifyString(str) {
+  console.log("함수 내부 - 전달받은 str:", str);
+  str = "변경된 문자열";
+  console.log("함수 내부 - 변경된 str:", str);
+}
+
+let originalStr = "원본 문자열";
+console.log("함수 호출 전 originalStr:", originalStr);
+modifyString(originalStr);
+console.log("함수 호출 후 originalStr:", originalStr);
+
+console.log("\n-------------------\n");
+
+// 3. Boolean 타입 실험
+function modifyBoolean(bool) {
+  console.log("함수 내부 - 전달받은 bool:", bool);
+  bool = false;
+  console.log("함수 내부 - 변경된 bool:", bool);
+}
+
+let originalBool = true;
+console.log("함수 호출 전 originalBool:", originalBool);
+modifyBoolean(originalBool);
+console.log("함수 호출 후 originalBool:", originalBool);

--- a/issue-03/reference-type-experiment.js
+++ b/issue-03/reference-type-experiment.js
@@ -1,0 +1,83 @@
+/**
+ * 참조형(Reference type) 객체의 함수 전달 시 동작 실험
+ * 객체 속성은 key-value 쌍과 동일
+ *
+ * JavaScript Reference Type:
+ * - Object
+ * - Array
+ * - Function
+ * - Date
+ * - RegExp
+ * - Map
+ * - Set
+ *
+ * 링크: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Data_structures#objects
+ */
+
+// 1. 객체의 프로퍼티 변경 실험
+function modifyObjectProperties(obj) {
+  console.log("함수 내부 - 전달받은 obj:", obj);
+  obj.name = "변경된 이름"; // 객체의 프로퍼티 변경
+  obj.age = 30; // 새로운 프로퍼티 추가
+  console.log("함수 내부 - 변경된 obj:", obj);
+}
+
+let originalObj = {
+  name: "원본 이름",
+  age: 25,
+};
+
+console.log("함수 호출 전 originalObj:", originalObj);
+modifyObjectProperties(originalObj);
+console.log("함수 호출 후 originalObj:", originalObj);
+
+console.log("\n-------------------\n");
+
+// 2. 객체 자체 재할당 실험
+function reassignObject(obj) {
+  console.log("함수 내부 - 전달받은 obj:", obj);
+  obj = {
+    // 새로운 객체로 재할당
+    name: "새로운 객체",
+    age: 40,
+  };
+  console.log("함수 내부 - 재할당된 obj:", obj);
+}
+
+let originalObj2 = {
+  name: "원본 객체",
+  age: 25,
+};
+
+console.log("함수 호출 전 originalObj2:", originalObj2);
+reassignObject(originalObj2);
+console.log("함수 호출 후 originalObj2:", originalObj2);
+
+console.log("\n-------------------\n");
+
+// 3. 배열의 요소 변경 실험
+function modifyArray(arr) {
+  console.log("함수 내부 - 전달받은 arr:", arr);
+  arr[0] = 100; // 배열 요소 변경
+  arr.push(4); // 새로운 요소 추가
+  console.log("함수 내부 - 변경된 arr:", arr);
+}
+
+let originalArr = [1, 2, 3];
+console.log("함수 호출 전 originalArr:", originalArr);
+modifyArray(originalArr);
+console.log("함수 호출 후 originalArr:", originalArr);
+
+console.log("\n-------------------\n");
+
+// 4. 배열 자체 재할당 실험
+function reassignArray(arr) {
+  console.log("함수 내부 - 전달받은 arr:", arr);
+  arr = [10, 20, 30, 40]; // 새로운 배열로 재할당
+  console.log("함수 내부 - 재할당된 arr:", arr);
+}
+
+let originalArr2 = [1, 2, 3];
+console.log("함수 호출 전 originalArr2:", originalArr2);
+reassignArray(originalArr2);
+console.log("함수 호출 후 originalArr2:", originalArr2);


### PR DESCRIPTION
## 1. 기본형(Primitive type) 변수의 함수 전달 시 복사 동작 확인
> issue-03/primitive-type-experiment.js에서 확인하실 수 있습니다.

기본형은 스택 영역에 새로운 공간(주소)을 할당받고, 그 안에 기존 값이 복사되는 방식으로 동작합니다.
- 모든 기본형 타입은 함수 내부에서 값을 변경하면, 복사된 주소 공간의 값을 변경합니다.
- 원본 값을 변경하지 않습니다.

## 2. 참조형(Reference type) 객체의 내부 프로퍼티 변경과 변수 자체 재할당 실험
> issue-03/reference-type-experiment.js에서 확인하실 수 있습니다.

참조형도 기본형과 유사한 방식으로 스택 영역에 새로운 공간을 할당받습니다. 다만 기본형과 달리 기존에 가리키던 주소가 복사되는 방식으로 동작합니다.
- 함수 내부에서 객체의 프로퍼티나 배열의 요소를 변경하면, 동일한 힙 메모리를 참조하고 있기 때문에 원본 데이터가 변경됩니다.
- 그러나 함수 내부에서 **객체나 배열 자체를 새로운 값으로 재할당하면, 해당 참조는 원본에 영향을 주지 않습니다.**

자바스크립트에서 참조 값을 전달하는 과정은 아래 게시물의 Call by Sharing 섹션을 참고해주시면 감사하겠습니다. (너무 정리를 잘 해주셨..)

- [[JS] 📚 Call by Value & Call by Reference (+ Call by Sharing)](https://inpa.tistory.com/entry/JS-%F0%9F%93%9A-Call-by-Value-Call-by-Reference)

> [!TIP]
> Q. 자바스크립트는 Call by Value만 지원하는건가요?
>
> A. 네, 자바스크립트는 모든 함수 인자 전달을 "값 복사(Call by Value)" 방식으로 처리합니다. 이때 참조형을 넘기는 경우, 객체 자체가 아니라 객체를 가리키는 "참조값(주소)"이 복사되어 전달됩니다. 즉, **복사되는 건 언제나 "값(value)"이며, 그 값이 기본형이면 실제 데이터, 참조형이면 **주소값(참조)**인 것**뿐입니다. 그렇기 때문에 자바스크립트는 항상 값에 의한 전달(Call By Value)만 존재한다고 말할 수 있습니다.

## 용어 정리

| 용어 | 뜻 | 자바스크립트에서의 의미 |
| -- | -- | -- |
| **Call by Value** | 함수에 값을 복사해서 전달 | 기본형(Primitive)과 참조형 모두 "값 자체"를 복사함 |
| **Call by Reference** | 함수에 변수의 주소를 전달 | JS에서는 없음, 변수의 참조 자체를 전달하지 않음 |
| **Call by Sharing** | 참조값(주소)을 복사해서 전달 | JS의 참조형(객체, 배열 등) 전달 방식과 정확히 일치함 |